### PR TITLE
Add checks on format query string param

### DIFF
--- a/src/controllers/matomo.js
+++ b/src/controllers/matomo.js
@@ -47,7 +47,7 @@ export default async (req, res) => {
 
   if (!req.query?.format) {
     params = `${params}&format=JSON`;
-  } else if (typeof req.query.format !== 'string' || (typeof req.query.format === 'string' && req.query.format.toLowerCase() !== 'json')) {
+  } else if (typeof req.query.format !== 'string' || req.query.format.toLowerCase() !== 'json') {
     return res.status(400).json({ error: messages.errors.malformedParameters });
   }
 

--- a/src/controllers/matomo.js
+++ b/src/controllers/matomo.js
@@ -47,10 +47,8 @@ export default async (req, res) => {
 
   if (!req.query?.format) {
     params = `${params}&format=JSON`;
-  } else if (typeof req.query.format !== 'string') {
+  } else if (typeof req.query.format !== 'string' || (typeof req.query.format === 'string' && req.query.format.toLowerCase() !== 'json')) {
     return res.status(400).json({ error: messages.errors.malformedParameters });
-  } else if (req.query.format.toLowerCase() !== 'json') {
-    params = params.replace(/(\?|&)(format=\w+(?=&|$))/gi, '&format=JSON');
   }
 
   const { method } = req;

--- a/src/controllers/matomo.js
+++ b/src/controllers/matomo.js
@@ -43,7 +43,16 @@ export default async (req, res) => {
     }
   }
 
-  const params = req.originalUrl;
+  let params = req.originalUrl;
+
+  if (!req.query?.format) {
+    params = `${params}&format=JSON`;
+  } else if (typeof req.query.format !== 'string') {
+    return res.status(400).json({ error: messages.errors.malformedParameters });
+  } else if (req.query.format.toLowerCase() !== 'json') {
+    params = params.replace(/(\?|&)(format=\w+(?=&|$))/gi, '&format=JSON');
+  }
+
   const { method } = req;
   const url = process.env.ANALYTICS_PUBLIC_URL + encodeURI(params);
 

--- a/tests/api.test.js
+++ b/tests/api.test.js
@@ -526,6 +526,30 @@ describe('api tests', () => {
     expect(res.body).toStrictEqual(response);
   });
 
+  it('forbidden format in query string', async () => {
+    expect.assertions(2);
+
+    const response = {
+      error: messages.default.errors.malformedParameters,
+    };
+
+    const queryTest = { ...query, format: 'XML' };
+    const queryTestParsed = querystring.encode(queryTest);
+
+    customId.siteId = [];
+    customId.siteId.push({
+      id: 1,
+      permission: 'RW',
+    });
+
+    const res = await request(app)
+      .get(`/?${queryTestParsed}`)
+      .set('x-consumer-custom-id', JSON.stringify(customId));
+
+    expect(res.status).toBe(400);
+    expect(res.body).toStrictEqual(response);
+  });
+
   it('missing format param in query string is added', async () => {
     expect.assertions(2);
 
@@ -543,39 +567,6 @@ describe('api tests', () => {
     fetch.mockReturnValue(Promise.resolve(new Response(JSON.stringify(response), responseInit)));
 
     const { format, ...queryTest } = { ...query };
-    const queryTestParsed = querystring.encode(queryTest);
-
-    customId.siteId = [];
-    customId.siteId.push({
-      id: 1,
-      permission: 'RW',
-    });
-
-    const res = await request(app)
-      .get(`/?${queryTestParsed}`)
-      .set('x-consumer-custom-id', JSON.stringify(customId));
-
-    expect(res.status).toBe(200);
-    expect(res.body).toStrictEqual(response);
-  });
-
-  it('wrong query string format parameter is corrected', async () => {
-    expect.assertions(2);
-
-    const response = {
-      requestedKey: 'requestedValue',
-    };
-
-    const responseInit = {
-      status: 200,
-      headers: new Headers({
-        'Content-Type': 'application/json',
-      }),
-    };
-
-    fetch.mockReturnValue(Promise.resolve(new Response(JSON.stringify(response), responseInit)));
-
-    const queryTest = { ...query, format: 'XML' };
     const queryTestParsed = querystring.encode(queryTest);
 
     customId.siteId = [];

--- a/tests/api.test.js
+++ b/tests/api.test.js
@@ -501,4 +501,94 @@ describe('api tests', () => {
       message: 'Error in backend network',
     });
   });
+
+  it('malformed format in query string', async () => {
+    expect.assertions(2);
+
+    const response = {
+      error: messages.default.errors.malformedParameters,
+    };
+
+    const queryTest = { ...query, format: ['JSON', 'JSON'] };
+    const queryTestParsed = querystring.encode(queryTest);
+
+    customId.siteId = [];
+    customId.siteId.push({
+      id: 1,
+      permission: 'RW',
+    });
+
+    const res = await request(app)
+      .get(`/?${queryTestParsed}`)
+      .set('x-consumer-custom-id', JSON.stringify(customId));
+
+    expect(res.status).toBe(400);
+    expect(res.body).toStrictEqual(response);
+  });
+
+  it('missing format param in query string is added', async () => {
+    expect.assertions(2);
+
+    const response = {
+      requestedKey: 'requestedValue',
+    };
+
+    const responseInit = {
+      status: 200,
+      headers: new Headers({
+        'Content-Type': 'application/json',
+      }),
+    };
+
+    fetch.mockReturnValue(Promise.resolve(new Response(JSON.stringify(response), responseInit)));
+
+    const { format, ...queryTest } = { ...query };
+    const queryTestParsed = querystring.encode(queryTest);
+
+    customId.siteId = [];
+    customId.siteId.push({
+      id: 1,
+      permission: 'RW',
+    });
+
+    const res = await request(app)
+      .get(`/?${queryTestParsed}`)
+      .set('x-consumer-custom-id', JSON.stringify(customId));
+
+    expect(res.status).toBe(200);
+    expect(res.body).toStrictEqual(response);
+  });
+
+  it('wrong query string format parameter is corrected', async () => {
+    expect.assertions(2);
+
+    const response = {
+      requestedKey: 'requestedValue',
+    };
+
+    const responseInit = {
+      status: 200,
+      headers: new Headers({
+        'Content-Type': 'application/json',
+      }),
+    };
+
+    fetch.mockReturnValue(Promise.resolve(new Response(JSON.stringify(response), responseInit)));
+
+    const queryTest = { ...query, format: 'XML' };
+    const queryTestParsed = querystring.encode(queryTest);
+
+    customId.siteId = [];
+    customId.siteId.push({
+      id: 1,
+      permission: 'RW',
+    });
+
+    const res = await request(app)
+      .get(`/?${queryTestParsed}`)
+      .set('x-consumer-custom-id', JSON.stringify(customId));
+
+    expect(res.status).toBe(200);
+    expect(res.body).toStrictEqual(response);
+  });
 });


### PR DESCRIPTION
Aggiungo dei controlli sul param "format" per assicurarsi che esista e che sia JSON, altrimenti lo aggiungo.
@pdavide ho anche aggiunto un controllo che in caso l'utente inserisca un altro formato questo viene poi trasformato in `format=JSON`. Lo teniamo così o diamo un errore all'utente?

resolve #17 